### PR TITLE
Add CMake for C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# C
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(WiiNo VERSION 1.0)
+
+add_executable(wiino wiino.cpp)
+
+install(FILES wiino DESTINATION bin)


### PR DESCRIPTION
This adds the commonly used distro-wide (Windows and Linux/Mac) CMake build system. This should take care of the fact that you get linker errors just blankly compiling wiino.cpp. This will fix that along with having an install option and if we wanted to, even make a library for pkgconfig using the header files we have (story for another time?)

I also would've done something for Go (maybe setup a go.mod?) and Python (by using python3-setuptools) but both don't work, they don't have a main function so I'll come back to them. I also added a .gitignore and will eventually when all three languages are fixed up and all update the README. Lmk if there is anything wrong, the versions are based off of the oldest current supported Ubuntu cmake version of Bionic Beaver (3.10), which should be old enough for most Windows systems to have it.

------------------------------------------------------------------------------------
I'm a dev who uses linux and my profile README should explain me basically. I want to contribute to RC24 I just don't know how so I hope here is a start.
