### PR TITLE
Remove extra calculations

### DIFF
--- a/python/wiino.py
+++ b/python/wiino.py
@@ -51,9 +51,6 @@ def getUnScrambleID(mix_id):
     mix_id ^= 0x00005E5E5E5E5E5E
     mix_id &= 0x001FFFFFFFFFFFFF
     
-    mix_id_copy2 = mix_id
-
-    mix_id_copy2 ^= 0xFF
     mix_id_copy2 = (mix_id << 5) & 0x20
 
     mix_id |= mix_id_copy2 << 48


### PR DESCRIPTION
Perhaps its a typo, but setting mid_id_copy2 to something only then to set it to something else seems like a typo. Perhaps I'm missing something?